### PR TITLE
Fix 1px gap between rows in Cocoa

### DIFF
--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -71,7 +71,7 @@ namespace XtermSharp.Mac {
 			var line = new CTLine (new NSAttributedString ("W", new NSStringAttributes () { Font = fontNormal }));
 			var bounds = line.GetBounds (CTLineBoundsOptions.UseOpticalBounds);
 			cellWidth = bounds.Width;
-			cellHeight = bounds.Height;
+			cellHeight = (int)bounds.Height;
 			cellDelta = bounds.Y;
 		}
 


### PR DESCRIPTION
Fixes #8 

Not 100% sure that this is the correct fix, but I tested at every font size and it worked for all.