### PR TITLE
Use $(SolutionDir) for path to the packages

### DIFF
--- a/XtermSharp.Mac/XtermSharp.Mac.csproj
+++ b/XtermSharp.Mac/XtermSharp.Mac.csproj
@@ -53,7 +53,7 @@
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Mac" />
     <Reference Include="NStack">
-      <HintPath>..\packages\NStack.Core.0.12.0\lib\netstandard1.5\NStack.dll</HintPath>
+      <HintPath>$(SolutionDir)\packages\NStack.Core.0.12.0\lib\netstandard1.5\NStack.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
This fixes nuget package restore when XtermSharp is used as a git submodule of another project.