### PR TITLE
[Pty] Remove the DllImport hard path

### DIFF
--- a/MacTerminal/MacTerminal.csproj
+++ b/MacTerminal/MacTerminal.csproj
@@ -96,4 +96,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
+  <Target Name="AfterBuild">
+    <Copy SourceFiles="..\helper\libpty.dylib" DestinationFolder="$(OutputPath)\MacTerminal.app\Contents\MonoBundle" />
+  </Target>
 </Project>

--- a/XtermSharp/Pty.cs
+++ b/XtermSharp/Pty.cs
@@ -18,7 +18,7 @@ namespace XtermSharp {
 		[DllImport ("libc")]
 		extern static int execve (string process, string [] args, string [] env);
 
-		[DllImport ("/cvs/XtermSharp/helper/libpty.dylib", EntryPoint ="fork_and_exec")]
+		[DllImport ("libpty.dylib", EntryPoint="fork_and_exec")]
 		extern static int HeavyFork (string process, string [] args, string [] env, out int master, UnixWindowSize winSize);
 
 		static bool HeavyDuty = true;


### PR DESCRIPTION
Let the client copy the .dylib to wherever it needs it.