### PR TITLE
Mac support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ Thumbs.db
 
 # dotCover
 *.dotCover
+.vs
+libpty.dylib

--- a/GuiCsHost/TerminalView.cs
+++ b/GuiCsHost/TerminalView.cs
@@ -356,7 +356,7 @@ namespace GuiCsHost {
 	public class SubprocessTerminalView : TerminalView {
 		int ptyFd;
 		int childPid;
-
+		
 		void SendDataToChild (byte [] data)
 		{
 			unsafe {

--- a/MacTerminal/AppDelegate.cs
+++ b/MacTerminal/AppDelegate.cs
@@ -18,6 +18,11 @@ namespace MacTerminal {
 			// Insert code here to tear down your application
 		}
 
+		public override bool ApplicationShouldTerminateAfterLastWindowClosed (NSApplication sender)
+		{
+			return true;
+		}
+
 		static void Main (string [] args)
 		{
 			NSApplication.Init ();

--- a/MacTerminal/ViewController.cs
+++ b/MacTerminal/ViewController.cs
@@ -28,6 +28,7 @@ namespace MacTerminal {
 		{
 			base.ViewDidLayout ();
 			terminalControl.Frame = View.Frame;
+			terminalControl.NeedsLayout = true;
 		}
 
 		public override NSObject RepresentedObject {

--- a/MacTerminal/ViewController.cs
+++ b/MacTerminal/ViewController.cs
@@ -6,93 +6,28 @@ using System;
 using AppKit;
 using Foundation;
 using XtermSharp.Mac;
-using XtermSharp;
-using ObjCRuntime;
-using CoreFoundation;
-using System.Runtime.InteropServices;
-using System.Collections.Generic;
 
 namespace MacTerminal {
 	public partial class ViewController : NSViewController {
-		TerminalView terminalView;
+		TerminalControl terminalControl;
 
 		public ViewController (IntPtr handle) : base (handle)
 		{
 		}
 
-		int pid, fd;
-		byte [] readBuffer = new byte [4*1024];
-
-		static int x;
-		void ChildProcessRead (DispatchData data, int error)
-		{
-			using (var map = data.CreateMap (out var buffer, out var size)) {
-				// Faster, but harder to debug:
-				// terminalView.Feed (buffer, (int) size);
-				//Console.WriteLine ("Read {0} bytes", size);
-				if (size == 0) {
-					View.Window.Close ();
-					return;
-				}
-				byte [] copy = new byte [(int)size];
-				Marshal.Copy (buffer, copy, 0, (int)size);
-
-				System.IO.File.WriteAllBytes ("/tmp/log-" + (x++), copy);
-				terminalView.Feed (copy);
-			}
-			DispatchIO.Read (fd, (nuint)readBuffer.Length, DispatchQueue.CurrentQueue, ChildProcessRead);
-		}
-
-		void ChildProcessWrite (DispatchData left, int error)
-		{
-			if (error != 0) {
-				throw new Exception ("Error writing data to child");
-			}
-		}
-
-		void GetSize (Terminal terminal, ref UnixWindowSize size)
-		{
-			 size = new UnixWindowSize () { 
-				col = (short)terminal.Cols, 
-				row = (short)terminal.Rows, 
-			 	xpixel = (short)View.Frame.Width, 
-		 		ypixel = (short)View.Frame.Height 
- 			};
-		}
-
 		public override void ViewDidLoad ()
 		{
 			base.ViewDidLoad ();
-			terminalView = new TerminalView (View.Frame);
-			var t = terminalView.Terminal;
-			var size = new UnixWindowSize ();
-			GetSize (t, ref size);
+			terminalControl = new TerminalControl (View.Frame);
+			View.AddSubview (terminalControl);
 
-			pid = Pty.ForkAndExec ("/bin/bash", new string [] { "/bin/bash" }, Terminal.GetEnvironmentVariables (), out fd, size);
-			DispatchIO.Read (fd, (nuint) readBuffer.Length, DispatchQueue.CurrentQueue, ChildProcessRead);
-
-			
-			terminalView.UserInput += (byte [] data) => {
-				DispatchIO.Write (fd, DispatchData.FromByteBuffer (data), DispatchQueue.CurrentQueue, ChildProcessWrite);
-			};
-			terminalView.Feed ("Welcome to XtermSharp - NSView frontend!\n");
-			terminalView.TitleChanged += (TerminalView sender, string title) => {
-				View.Window.Title = title;
-			};
-			terminalView.SizeChanged += (newCols, newRows) => {
-				UnixWindowSize nz = new UnixWindowSize ();
-				GetSize (t, ref nz);
-				var res = Pty.SetWinSize (fd, ref nz);
-				Console.WriteLine (res);
-			};
-			View.AddSubview (terminalView);
-
+			terminalControl.StartShell ();
 		}
 
 		public override void ViewDidLayout ()
 		{
 			base.ViewDidLayout ();
-			terminalView.Frame = View.Frame;
+			terminalControl.Frame = View.Frame;
 		}
 
 		public override NSObject RepresentedObject {

--- a/MacTerminal/ViewController.cs
+++ b/MacTerminal/ViewController.cs
@@ -19,6 +19,9 @@ namespace MacTerminal {
 		{
 			base.ViewDidLoad ();
 			terminalControl = new TerminalControl (View.Frame);
+			terminalControl.ShellExited += () => {
+				View.Window.Close ();
+			};
 			View.AddSubview (terminalControl);
 
 			terminalControl.StartShell ();

--- a/TODO.md
+++ b/TODO.md
@@ -3,7 +3,7 @@
 
 General bits:
 * Resize
-* Buffer managerment and scrollback support
+* Buffer management and scrollback support
 * Rendering glitches in Mac port (the in-between line thing)
 * Mouse support
 * Caret shape support
@@ -14,7 +14,7 @@ Porting:
 - [ ] AccessibilityManager.ts
 - [x] Buffer.ts
 - [x] BufferLine.ts
-- [ ] BufferReflow.ts
+- [x] BufferReflow.ts
 - [x] BufferSet.ts
 - [x] CharWidth.ts
 - [ ] CompositionHelper.ts
@@ -24,7 +24,7 @@ Porting:
 - [ ] SelectionManager.ts
 - [ ] SelectionModel.ts
 - [ ] SoundManager.ts
-- [   ] Strings.ts
+- [ ] Strings.ts
 - [ ] Terminal.integration.ts
 - [ ] Terminal.ts
 - [ ] Types.ts

--- a/XtermSharp.Mac/SelectionView.cs
+++ b/XtermSharp.Mac/SelectionView.cs
@@ -1,0 +1,240 @@
+﻿using System;
+using AppKit;
+using CoreGraphics;
+using CoreAnimation;
+using System.Drawing;
+using System.Collections.Generic;
+
+namespace XtermSharp.Mac {
+	/// <summary>
+	/// Implements a view that is used to show the current selection in the terminal
+	/// </summary>
+	class SelectionView : NSView {
+		readonly PointComparer comparer;
+		readonly Terminal terminal;
+		readonly nfloat rowHeight;
+		readonly nfloat colWidth;
+		readonly nfloat rowDelta;
+		readonly CAShapeLayer maskLayer;
+		NSColor selectionColor;
+
+		public SelectionView (Terminal terminal, CGRect rect, CGRect typgographicalBounds) : base (rect)
+		{
+			this.terminal = terminal;
+
+			comparer = new PointComparer ();
+			rowHeight = (int)typgographicalBounds.Height;
+			colWidth = typgographicalBounds.Width;
+			rowDelta = typgographicalBounds.Y;
+
+			WantsLayer = true;
+			maskLayer = new CAShapeLayer ();
+			Layer.Mask = maskLayer;
+		}
+
+		/// <summary>
+		/// Gets or sets the color used to show selection
+		/// </summary>
+		public NSColor SelectionColor {
+			get => selectionColor;
+			set {
+				selectionColor = value;
+				Layer.BackgroundColor = selectionColor.CGColor;
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the selection start point in buffer coordinates
+		/// </summary>
+		public Point Start { get; private set; }
+
+		/// <summary>
+		/// Gets or sets the selection end point in buffer coordinates
+		/// </summary>
+		public Point End { get; private set; }
+
+		public void SetStart(int row, int col)
+		{
+			Start = End = new Point (col, row + terminal.Buffer.YDisp);
+			UpdateMask ();
+		}
+
+		/// <summary>
+		/// Extends the selection based on the user "shift" clicking. This has
+		/// slightly different semantics than a "drag" extension because we can
+		/// shift the start to be the last prior end point if the new extension
+		/// is before the current start point. 
+		/// </summary>
+		public void ShiftExtend (int row, int col)
+		{
+			var newEnd = new Point (col, row + terminal.Buffer.YDisp);
+
+			var shouldSwapStart = false;
+			if (comparer.Compare(Start, End) < 0) {
+				// start is before end, is the new end before Start
+				if (comparer.Compare(newEnd, Start) < 0) {
+					// yes, swap Start and End
+					shouldSwapStart = true;
+				}
+			} else if (comparer.Compare (Start, End) > 0) {
+				if (comparer.Compare (newEnd, Start) > 0) {
+					// yes, swap Start and End
+					shouldSwapStart = true;
+				}
+			}
+
+			if (shouldSwapStart) {
+				Start = End;
+			}
+
+			End = newEnd;
+			UpdateMask ();
+		}
+
+		/// <summary>
+		/// Extends the selection by moving the end point to the new point.
+		/// This may set the end point
+		/// </summary>
+		public void DragExtend (int row, int col)
+		{
+			End = new Point (col, row + terminal.Buffer.YDisp);
+			UpdateMask ();
+		}
+
+		/// <summary>
+		/// Notify that the terminal contents were scrolled and that we need
+		/// to update the selection coordinates
+		/// </summary>
+		public void NotifyScrolled()
+		{
+			UpdateMask ();
+		}
+
+		void UpdateMask ()
+		{
+			// remove the prior mask
+			maskLayer.Path?.Dispose ();
+
+			maskLayer.Frame = Bounds;
+			var path = new CGPath ();
+
+			var screenRowStart = Start.Y - terminal.Buffer.YDisp;
+			var screenRowEnd = End.Y - terminal.Buffer.YDisp;
+
+			// mask the row that contains the start position
+			// snap to either the first or last column depending on
+			// where the end position is in relation to the start
+			int col = End.X;
+			if (screenRowEnd > screenRowStart)
+				col = terminal.Cols;
+			if (screenRowEnd < screenRowStart)
+				col = 0;
+
+			MaskPartialRow (path, screenRowStart, Start.X,  col);
+
+			if (screenRowStart == screenRowEnd) {
+				// we're done, only one row to mask
+				maskLayer.Path = path;
+				return;
+			}
+
+			// now mask the row with the end position
+			col = Start.X;
+			if (screenRowEnd > screenRowStart)
+				col = 0;
+			if (screenRowEnd < screenRowStart)
+				col = terminal.Cols;
+			MaskPartialRow (path, screenRowEnd, col, End.X);
+
+			// now mask any full rows in between
+			var fullRowCount = screenRowEnd - screenRowStart;
+			if (fullRowCount > 1) {
+				// Mask full rows up to the last row
+				MaskFullRows (path, screenRowStart + 1, fullRowCount-1);
+			} else if (fullRowCount < -1) {
+				// Mask full rows up to the last row
+				MaskFullRows (path, screenRowStart - 0, fullRowCount+1);
+			}
+
+			maskLayer.Path = path;
+		}
+
+		void MaskFullRows (CGPath path, int rowStart, int rowCount)
+		{
+			int cursorYOffset = 2;
+
+			nfloat startY = Frame.Height  - ((rowStart + rowCount) * rowHeight - rowDelta - cursorYOffset);
+			var pathRect = new CGRect (
+				0,
+				startY,
+				Frame.Width,
+				rowHeight * rowCount);
+
+			path.AddRect (pathRect);
+		}
+
+		void MaskPartialRow (CGPath path, int row, int colStart, int colEnd)
+		{
+			// -2 to get the top of the selection to fit over the top of the text properly
+			// and to align with the cursor
+			const int cursorXPadding = 1;
+			int cursorYOffset = 2;
+
+			CGRect pathRect;
+
+			nfloat startY = Frame.Height - rowHeight - (row * rowHeight - rowDelta - cursorYOffset);
+			nfloat startX = colStart * colWidth;
+
+			if (colStart == colEnd) {
+				// basically the same as the cursor
+				pathRect = new CGRect (
+					startX - cursorXPadding,
+					startY,
+					colWidth + (2 * cursorXPadding),
+					rowHeight);
+
+				path.AddRect (pathRect);
+				return;
+			}
+
+			if (colStart < colEnd) {
+				// start before the beginning of the start column and end just before the start of the next column
+				pathRect = new CGRect (
+					startX - cursorXPadding,
+					startY,
+					((colEnd - colStart) * colWidth) + (2 * cursorXPadding),
+					rowHeight);
+
+				path.AddRect (pathRect);
+				return;
+			}
+
+			// start before the beginning of the _end_ column and end just before the start of the _start_ column
+			// note this creates a rect with negative width
+			pathRect = new CGRect (
+				startX + cursorXPadding,
+				startY,
+				((colEnd - colStart) * colWidth) - (2 * cursorXPadding),
+				rowHeight);
+
+			path.AddRect (pathRect);
+		}
+
+		class PointComparer : IComparer<Point> {
+			public int Compare (Point x, Point y)
+			{
+				if (x.Y < y.Y)
+					return -1;
+				if (x.Y > y.Y)
+					return 1;
+				// x and y are on the same row, compare columns
+				if (x.X < y.X)
+					return -1;
+				if (x.X > y.X)
+					return 1;
+				// they are the same
+				return 0;
+			}
+		}
+	}
+}

--- a/XtermSharp.Mac/TerminalControl.cs
+++ b/XtermSharp.Mac/TerminalControl.cs
@@ -112,7 +112,19 @@ namespace XtermSharp.Mac {
 
 		void ScrollerActivated (object sender, EventArgs e)
 		{
-			terminalView.ScrollToPosition (scroller.DoubleValue);
+			switch (scroller.HitPart) {
+			case NSScrollerPart.DecrementPage:
+				terminalView.PageUp ();
+				scroller.DoubleValue = terminalView.ScrollPosition;
+				break;
+			case NSScrollerPart.IncrementPage:
+				terminalView.PageDown ();
+				scroller.DoubleValue = terminalView.ScrollPosition;
+				break;
+			case NSScrollerPart.Knob:
+				terminalView.ScrollToPosition (scroller.DoubleValue);
+				break;
+			}
 		}
 
 		void HandleUserInput (byte [] data)

--- a/XtermSharp.Mac/TerminalControl.cs
+++ b/XtermSharp.Mac/TerminalControl.cs
@@ -26,10 +26,17 @@ namespace XtermSharp.Mac {
 
 		public string WelcomeText { get; set; } = "Welcome to XtermSharp!";
 
+		public string ExitText { get; set; } = string.Empty;
+
 		/// <summary>
 		/// Raised when the title of the terminal has changed
 		/// </summary>
 		public event Action<string> TitleChanged;
+
+		/// <summary>
+		/// Raised when the title of the shell process exits
+		/// </summary>
+		public event Action ShellExited;
 
 		/// <summary>
 		/// Launches the shell
@@ -162,7 +169,10 @@ namespace XtermSharp.Mac {
 				// Faster, but harder to debug:
 				// terminalView.Feed (buffer, (int) size);
 				if (size == 0) {
-					//View.Window.Close ();
+					if (!string.IsNullOrEmpty(ExitText))
+						terminalView.Terminal.Feed (ExitText);
+
+					ShellExited?.Invoke ();
 					return;
 				}
 				byte [] copy = new byte [(int)size];

--- a/XtermSharp.Mac/TerminalControl.cs
+++ b/XtermSharp.Mac/TerminalControl.cs
@@ -16,9 +16,9 @@ namespace XtermSharp.Mac {
 		int shellFileDescriptor;
 		readonly byte [] readBuffer = new byte [4 * 1024];
 
-		// TODO: we need to clean up files left around from this
+#if DEBUG
 		static int x;
-
+#endif
 		public TerminalControl (CGRect rect) : base (rect)
 		{
 			Build (rect);
@@ -137,7 +137,9 @@ namespace XtermSharp.Mac {
 				byte [] copy = new byte [(int)size];
 				Marshal.Copy (buffer, copy, 0, (int)size);
 
+#if DEBUG
 				System.IO.File.WriteAllBytes ("/tmp/log-" + (x++), copy);
+#endif
 				terminalView.Feed (copy);
 			}
 

--- a/XtermSharp.Mac/TerminalControl.cs
+++ b/XtermSharp.Mac/TerminalControl.cs
@@ -41,7 +41,7 @@ namespace XtermSharp.Mac {
 		/// <summary>
 		/// Launches the shell
 		/// </summary>
-		public void StartShell(string shellPath = "/bin/bash")
+		public void StartShell(string shellPath = "/bin/bash", string [] args = null)
 		{
 			// TODO: throw error if already started
 			terminalView.Feed (WelcomeText + "\n");
@@ -49,7 +49,11 @@ namespace XtermSharp.Mac {
 			var size = new UnixWindowSize ();
 			GetUnixWindowSize (terminalView.Frame, terminalView.Terminal.Rows, terminalView.Terminal.Cols, ref size);
 
-			shellPid = Pty.ForkAndExec (shellPath, new string [] { shellPath }, Terminal.GetEnvironmentVariables (), out shellFileDescriptor, size);
+			var shellArgs = args == null ? new string [1] : new string [args.Length + 1];
+			shellArgs [0] = shellPath;
+			args?.CopyTo (shellArgs, 1);
+
+			shellPid = Pty.ForkAndExec (shellPath, shellArgs, Terminal.GetEnvironmentVariables (), out shellFileDescriptor, size);
 			DispatchIO.Read (shellFileDescriptor, (nuint)readBuffer.Length, DispatchQueue.CurrentQueue, ChildProcessRead);
 		}
 

--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -196,6 +196,10 @@ namespace XtermSharp.Mac {
 
 		NSAttributedString BuildAttributedString (BufferLine line, int cols)
 		{
+			if (line == null) {
+				return new NSAttributedString (string.Empty, GetAttributes (CharData.Null.Attribute));
+			}
+
 			var res = new NSMutableAttributedString ();
 			int attr = 0;
 

--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -1036,7 +1036,11 @@ namespace XtermSharp.Mac {
 					ScrollDown (velocity);
 				}
 			}
+		}
 
+		public override void ResetCursorRects ()
+		{
+			AddCursorRect (Bounds, NSCursor.IBeamCursor);
 		}
 	}
 }

--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -538,6 +538,8 @@ namespace XtermSharp.Mac {
 
 		public override void KeyDown (NSEvent theEvent)
 		{
+			StopSelecting ();
+
 			var eventFlags = theEvent.ModifierFlags;
 
 			// Handle Option-letter to send the ESC sequence plus the letter as expected by terminals

--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -386,6 +386,11 @@ namespace XtermSharp.Mac {
 					return true;
 				}
 				return false;
+			case "paste:":
+				return true;
+			case "copy:":
+				// TODO: tell if we are actually selecting something
+				return true;
 			}
 
 			Console.WriteLine ("Validating " + selector);
@@ -394,15 +399,26 @@ namespace XtermSharp.Mac {
 
 		[Export ("cut:")]
 		void Cut (NSObject sender)
-		{ }
+		{
+		}
 
 		[Export ("copy:")]
 		void Copy (NSObject sender)
-		{ }
+		{
+			// find the selected range of text in the buffer and put in the clipboard
+			var str = selectionView.GetSelectedText();
+
+			var clipboard = NSPasteboard.GeneralPasteboard;
+			clipboard.ClearContents ();
+			clipboard.SetStringForType (str, NSPasteboard.NSPasteboardTypeString);
+		}
 
 		[Export ("paste:")]
 		void Paste (NSObject sender)
 		{
+			var clipboard = NSPasteboard.GeneralPasteboard;
+			var text = clipboard.GetStringForType (NSPasteboard.NSPasteboardTypeString);
+			InsertText (text, new NSRange(0, 0));
 		}
 
 		[Export ("selectAll:")]
@@ -549,6 +565,15 @@ namespace XtermSharp.Mac {
 			if (text is NSString str) {
 				var data = str.Encode (NSStringEncoding.UTF8);
 				Send (data.ToArray ());
+			}
+			NeedsDisplay = true;
+		}
+
+		void InsertText (string text, NSRange replacementRange)
+		{
+			if (!string.IsNullOrEmpty(text)) {
+				var data = Encoding.UTF8.GetBytes (text);
+				Send (data);
 			}
 			NeedsDisplay = true;
 		}

--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -290,7 +290,7 @@ namespace XtermSharp.Mac {
 				terminal.Buffer.X * cellWidth - 1,
 				// -2 to get the top of the selection to fit over the top of the text properly
 				// and to align with the cursor
-				Frame.Height - cellHeight - (terminal.Buffer.Y * cellHeight - cellDelta - 2),
+				Frame.Height - cellHeight - ((terminal.Buffer.Y + terminal.Buffer.YBase - terminal.Buffer.YDisp) * cellHeight - cellDelta - 2),
 				// +2 to pad outside the character a little bit on the other side
 				cellWidth + 2,
 				cellHeight + 0);

--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -153,7 +153,7 @@ namespace XtermSharp.Mac {
 				if (isFg)
 					return NSColor.Black;
 				else
-					return NSColor.White;
+					return NSColor.Clear;
 			} else if (color == Renderer.InvertedDefaultColor) {
 				if (isFg)
 					return NSColor.White;
@@ -233,7 +233,7 @@ namespace XtermSharp.Mac {
 						attr = ch.Attribute;
 					}
 				}
-				basBuilder.Append (ch.Code == 0 ? ' ' : (char)ch.Rune);
+				basBuilder.Append (ch.Code == 0 ? " " : ch.Rune.ToString());
 			}
 			res.Append (new NSAttributedString (basBuilder.ToString (), GetAttributes (attr)));
 			return res;
@@ -727,6 +727,8 @@ namespace XtermSharp.Mac {
 			NSGraphics.RectFill (dirtyRect);
 
 			CGContext context = NSGraphicsContext.CurrentContext.GraphicsPort;
+			context.SaveState ();
+
 			//context.TextMatrix = textMatrix;
 
 #if false
@@ -773,6 +775,8 @@ namespace XtermSharp.Mac {
 #endif
 
 			}
+
+			context.RestoreState ();
 #endif
 		}
 

--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -154,6 +154,40 @@ namespace XtermSharp.Mac {
 			}
 		}
 
+		public void PageUp()
+		{
+			int newPosition = Math.Max(Terminal.Buffer.YDisp - Terminal.Rows, 0);
+			if (newPosition != Terminal.Buffer.YDisp) {
+				Terminal.Buffer.YDisp = newPosition;
+
+				// tell the terminal we want to refresh all the rows
+				Terminal.Refresh (0, Terminal.Rows);
+
+				// do the display update
+				UpdateDisplay ();
+
+				selectionView.NotifyScrolled ();
+				TerminalScrolled?.Invoke (ScrollPosition);
+			}
+		}
+
+		public void PageDown ()
+		{
+			int newPosition = Math.Min (Terminal.Buffer.YDisp + Terminal.Rows, Terminal.Buffer.Lines.Length - Terminal.Rows);
+			if (newPosition != Terminal.Buffer.YDisp) {
+				Terminal.Buffer.YDisp = newPosition;
+
+				// tell the terminal we want to refresh all the rows
+				Terminal.Refresh (0, Terminal.Rows);
+
+				// do the display update
+				UpdateDisplay ();
+
+				selectionView.NotifyScrolled ();
+				TerminalScrolled?.Invoke (ScrollPosition);
+			}
+		}
+
 		void Terminal_Scrolled (Terminal terminal, int yDisp)
 		{
 			selectionView.NotifyScrolled ();
@@ -580,6 +614,12 @@ namespace XtermSharp.Mac {
 						break;
 					case NSFunctionKey.RightArrow:
 						Send (EscapeSequences.MoveRightNormal);
+						break;
+					case NSFunctionKey.PageUp:
+						PageUp ();
+						break;
+					case NSFunctionKey.PageDown:
+						PageDown ();
 						break;
 					}
 				}

--- a/XtermSharp.Mac/XtermSharp.Mac.csproj
+++ b/XtermSharp.Mac/XtermSharp.Mac.csproj
@@ -59,6 +59,7 @@
   <ItemGroup>
     <Compile Include="TerminalView.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TerminalControl.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/XtermSharp.Mac/XtermSharp.Mac.csproj
+++ b/XtermSharp.Mac/XtermSharp.Mac.csproj
@@ -60,6 +60,7 @@
     <Compile Include="TerminalView.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TerminalControl.cs" />
+    <Compile Include="SelectionView.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/XtermSharp/Buffer.cs
+++ b/XtermSharp/Buffer.cs
@@ -3,12 +3,11 @@ using System.Collections;
 using System.Diagnostics;
 using NStack;
 
-namespace XtermSharp
-{
+namespace XtermSharp {
 	/// <summary>
 	/// This class represents a terminal buffer (an internal state of the terminal), where text contents, cursor and scroll position are stored.
 	/// </summary>
-    	[DebuggerDisplay ("({X},{Y} YD{YDisp}:YB{YBase} Scroll={ScrollBottom,ScrollTop}")]
+	[DebuggerDisplay ("({X},{Y}) YD={YDisp}:YB={YBase} Scroll={ScrollBottom,ScrollTop}")]
 	public class Buffer {
 		CircularList<BufferLine> lines;
 		public int YDisp, YBase;
@@ -17,7 +16,7 @@ namespace XtermSharp
 		public int Y {
 			get => y;
 			set {
-				if (value < 0 || value > Terminal.Rows-1)
+				if (value < 0 || value > Terminal.Rows - 1)
 					throw new Exception ();
 				else
 					y = value;
@@ -39,6 +38,7 @@ namespace XtermSharp
 		public int SavedX, SavedY, SavedAttr = CharData.DefaultAttr;
 		public Terminal Terminal { get; private set; }
 		bool hasScrollback;
+		int cols, rows;
 
 		/// <summary>
 		/// Gets a value indicating whether this <see cref="T:XtermSharp.Buffer"/> has scrollback.
@@ -53,6 +53,8 @@ namespace XtermSharp
 		/// <param name="hasScrollback">Whether the buffer should respect the scrollback of the terminal.</param>
 		public Buffer (Terminal terminal, bool hasScrollback = true)
 		{
+			rows = terminal.Rows;
+			cols = terminal.Cols;
 			Terminal = terminal;
 			this.hasScrollback = hasScrollback;
 			Clear ();
@@ -61,7 +63,7 @@ namespace XtermSharp
 		public CircularList<BufferLine> Lines => lines;
 
 		// Gets the correct buffer length based on the rows provided, the terminal's
-   		// scrollback and whether this buffer is flagged to have scrollback or not.
+		// scrollback and whether this buffer is flagged to have scrollback or not.
 		int getCorrectBufferLength (int rows)
 		{
 			if (!hasScrollback)
@@ -72,7 +74,7 @@ namespace XtermSharp
 
 		public BufferLine GetBlankLine (int attribute, bool isWrapped = false)
 		{
-			var cd = new CharData (attribute); 
+			var cd = new CharData (attribute);
 
 			return new BufferLine (Terminal.Cols, cd, isWrapped);
 		}
@@ -113,6 +115,8 @@ namespace XtermSharp
 				lines.Push (GetBlankLine (attr));
 		}
 
+		bool IsReflowEnabled => hasScrollback;// && Terminal.Options.WindowsMode;
+
 		/// <summary>
 		/// Resize the buffer, adjusting its data accordingly
 		/// </summary>
@@ -121,11 +125,104 @@ namespace XtermSharp
 		/// <param name="newRows">New rows.</param>
 		public void Resize (int newCols, int newRows)
 		{
-			Clear ();
-			FillViewportRows ();
+			var newMaxLength = getCorrectBufferLength (newRows);
+			if (newMaxLength > lines.MaxLength) {
+				lines.MaxLength = newMaxLength;
+			}
 
-			// FIXME: should this not fill int he additional tab stops?   Bug in original
-			tabStops.Length = newCols;
+			if (this.lines.Length > 0) {
+				// Deal with columns increasing (reducing needs to happen after reflow)
+				if (cols < newCols) {
+					for (int i = 0; i < lines.Length; i++) {
+						lines [i]?.Resize (newCols, CharData.Null);
+					}
+				}
+
+				// Resize rows in both directions as needed
+				int addToY = 0;
+				if (rows < newRows) {
+					for (int y = rows; y < newRows; y++) {
+						if (lines.Length < newRows + YBase) {
+							//if (Terminal.Options.windowsMode) {
+							//	// Just add the new missing rows on Windows as conpty reprints the screen with it's
+							//	// view of the world. Once a line enters scrollback for conpty it remains there
+							//	lines.Push (new BufferLine (newCols, CharData.Null));
+							//} else {
+							{
+								if (YBase > 0 && lines.Length <= YBase + Y + addToY + 1) {
+									// There is room above the buffer and there are no empty elements below the line,
+									// scroll up
+									YBase--;
+									addToY++;
+									if (YDisp > 0) {
+										// Viewport is at the top of the buffer, must increase downwards
+										YDisp--;
+									}
+								} else {
+									// Add a blank line if there is no buffer left at the top to scroll to, or if there
+									// are blank lines after the cursor
+									lines.Push (new BufferLine (newCols, CharData.Null));
+								}
+							}
+						}
+					}
+				} else { // (this._rows >= newRows)
+					for (int y = rows; y > newRows; y--) {
+						if (lines.Length > newRows + YBase) {
+							if (lines.Length > YBase + this.y + 1) {
+								// The line is a blank line below the cursor, remove it
+								lines.Pop ();
+							} else {
+								// The line is the cursor, scroll down
+								YBase++;
+								YDisp++;
+							}
+						}
+					}
+				}
+
+				// Reduce max length if needed after adjustments, this is done after as it
+				// would otherwise cut data from the bottom of the buffer.
+				if (newMaxLength < lines.MaxLength) {
+					// Trim from the top of the buffer and adjust ybase and ydisp.
+					int amountToTrim = lines.Length - newMaxLength;
+					if (amountToTrim > 0) {
+						lines.TrimStart (amountToTrim);
+						YBase = Math.Max (YBase - amountToTrim, 0);
+						YDisp = Math.Max (YDisp - amountToTrim, 0);
+						SavedY = Math.Max (SavedY - amountToTrim, 0);
+					}
+
+					lines.MaxLength = newMaxLength;
+				}
+
+				// Make sure that the cursor stays on screen
+				X = Math.Min (X, newCols - 1);
+				Y = Math.Min (Y, newRows - 1);
+				if (addToY != 0) {
+					Y += addToY;
+				}
+
+				SavedX = Math.Min (SavedX, newCols - 1);
+
+				ScrollTop = 0;
+			}
+
+			ScrollBottom = newRows - 1;
+
+			if (IsReflowEnabled) {
+				this.Reflow (newCols, newRows);
+
+				// Trim the end of the line off if cols shrunk
+				if (cols > newCols) {
+					for (int i = 0; i < lines.Length; i++) {
+						lines [i]?.Resize (newCols, CharData.Null);
+					}
+				}
+			}
+
+			rows = newRows;
+			cols = newCols;
 		}
 
 		/// <summary>
@@ -150,17 +247,19 @@ namespace XtermSharp
 		/// <param name="index">Index to start setting tabs stops from.</param>
 		public void SetupTabStops (int index = -1)
 		{
-			int cols = Terminal.Cols;
-
 			if (index != -1 && tabStops != null) {
+				tabStops.Length = cols;
+
 				var from = Math.Min (index, cols - 1);
 				if (!tabStops [from])
 					index = PreviousTabStop (from);
-			} else 
+			} else {
 				tabStops = new BitArray (cols);
+				index = 0;
+			}
 
 			int tabStopWidth = Terminal.Options.TabStopWidth ?? 8;
-			for (int i = 0; i < cols; i += tabStopWidth)
+			for (int i = index; i < cols; i += tabStopWidth)
 				tabStops [i] = true;
 		}
 
@@ -202,7 +301,7 @@ namespace XtermSharp
 		/// <param name="index">The position to move the cursor one tab stop forward.</param>
 		public int NextTabStop (int index = -1)
 		{
-			if (index == -1) 
+			if (index == -1)
 				index = X;
 			do {
 				index++;
@@ -213,6 +312,22 @@ namespace XtermSharp
 			} while (index < Terminal.Cols);
 			return index >= Terminal.Cols ? Terminal.Cols - 1 : index;
 		}
-	}
 
+		void Reflow (int newCols, int newRows)
+		{
+			if (cols == newCols) {
+				return;
+			}
+
+			// Iterate through rows, ignore the last one as it cannot be wrapped
+			ReflowStrategy strategy;
+			if (newCols > cols) {
+				strategy = new ReflowWider (this);
+			} else {
+				strategy = new ReflowNarrower (this);
+			}
+
+			strategy.Reflow (newCols, newRows, cols, rows);
+		}
+	}
 }

--- a/XtermSharp/Buffer.cs
+++ b/XtermSharp/Buffer.cs
@@ -139,7 +139,9 @@ namespace XtermSharp
 		/// <param name="endCol">The column to end at.</param>
 		public ustring TranslateBufferLineToString (int lineIndex, bool trimRight, int startCol = 0, int endCol = -1)
 		{
-			throw new NotImplementedException ();
+			var line = lines [lineIndex];
+
+			return line.TranslateToString (trimRight, startCol, endCol);
 		}
 
 		/// <summary>

--- a/XtermSharp/BufferLine.cs
+++ b/XtermSharp/BufferLine.cs
@@ -3,9 +3,11 @@
 //
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using NStack;
 
 namespace XtermSharp {
+	[DebuggerDisplay ("Line: {DebuggerDisplay}")]
 	public class BufferLine {
 		CharData [] data = Array.Empty<CharData> ();
 		public int Length => data.Length;
@@ -36,6 +38,20 @@ namespace XtermSharp {
 		}
 
 		public int GetWidth (int index) => data [index].Width;
+
+		/**
+		   * Test whether contains any chars.
+		   * Basically an empty has no content, but other cells might differ in FG/BG
+		   * from real empty cells.
+		   * */
+		   // TODO: not sue this is completely right
+		public bool HasContent (int index) => data [index].Code != 0 && data [index].Attribute != CharData.DefaultAttr;
+
+		string DebuggerDisplay {
+			get {
+				return TranslateToString (true, 0, -1).ToString ();
+			}
+		}
 
 		public void InsertCells (int pos, int n, CharData fillCharData)
 		{
@@ -85,12 +101,14 @@ namespace XtermSharp {
 				var newData = new CharData [cols];
 				if (len > 0)
 					data.CopyTo (newData, 0);
+				data = newData;
 				for (int i = len; i < cols; i++)
 					data [i] = fillCharData;
 			} else {
 				if (cols > 0) {
 					var newData = new CharData [cols];
 					Array.Copy (data, newData, cols);
+					data = newData;
 				} else {
 					data = Array.Empty<CharData> ();
 				}

--- a/XtermSharp/BufferSet.cs
+++ b/XtermSharp/BufferSet.cs
@@ -27,6 +27,11 @@ namespace XtermSharp {
 		}
 
 		/// <summary>
+		/// Gets a value indicating whether the active buffer is the alternate buffer
+		/// </summary>
+		public bool IsAlternateBuffer => Active == Alt;
+
+		/// <summary>
 		/// Raised when a buffer is activated, the parameters is the buffer that was activated and the second parameter is the Inactive buffer.
 		/// </summary>
 		public event Action<Buffer, Buffer> Activated;

--- a/XtermSharp/InputHandler.cs
+++ b/XtermSharp/InputHandler.cs
@@ -2027,12 +2027,12 @@ namespace XtermSharp {
 								var chMinusTwo = bufferRow [buffer.X - 2];
 
 								chMinusTwo.Code += ch;
-								chMinusTwo.Rune = (Rune)code;
+								chMinusTwo.Rune = (uint)code;
 								bufferRow [buffer.X - 2] = chMinusTwo; // must be set explicitly now
 							}
 						} else {
 							chMinusOne.Code += ch;
-							chMinusOne.Rune = (Rune)code;
+							chMinusOne.Rune = (uint)code;
 							bufferRow [buffer.X - 1] = chMinusOne; // must be set explicitly now
 						}
 					}
@@ -2086,7 +2086,7 @@ namespace XtermSharp {
 				}
 
 				// write current char to buffer and advance cursor
-				var charData = new CharData (curAttr, (Rune)code, chWidth, ch);
+				var charData = new CharData (curAttr, (uint)code, chWidth, ch);
 				bufferRow [buffer.X++] = charData;
 
 				// fullwidth char - also set next cell to placeholder stub and advance cursor

--- a/XtermSharp/InputHandler.cs
+++ b/XtermSharp/InputHandler.cs
@@ -2055,7 +2055,7 @@ namespace XtermSharp {
 						} else {
 							// The line already exists (eg. the initial viewport), mark it as a
 							// wrapped line
-							buffer.Lines [buffer.Y++].IsWrapped = true;
+							buffer.Lines [++buffer.Y].IsWrapped = true;
 						}
 						// row changed, get it again
 						bufferRow = buffer.Lines [buffer.Y + buffer.YBase];

--- a/XtermSharp/ReflowNarrower.cs
+++ b/XtermSharp/ReflowNarrower.cs
@@ -1,0 +1,261 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace XtermSharp {
+	class ReflowNarrower : ReflowStrategy {
+		public ReflowNarrower (Buffer buffer) : base (buffer)
+		{
+		}
+
+		public override void Reflow (int newCols, int newRows, int oldCols, int oldRows)
+		{
+			// Gather all BufferLines that need to be inserted into the Buffer here so that they can be
+			// batched up and only committed once
+			List<InsertionSet> toInsert = new List<InsertionSet> ();
+			int countToInsert = 0;
+
+			// Go backwards as many lines may be trimmed and this will avoid considering them
+			for (int y = Buffer.Lines.Length - 1; y >= 0; y--) {
+				// Check whether this line is a problem or not, if not skip it
+				BufferLine nextLine = Buffer.Lines [y];
+				int lineLength = nextLine.GetTrimmedLength ();
+				if (!nextLine.IsWrapped && lineLength <= newCols) {
+					continue;
+				}
+
+				// Gather wrapped lines and adjust y to be the starting line
+				List<BufferLine> wrappedLines = new List<BufferLine> ();
+				wrappedLines.Add (nextLine);
+				while (nextLine.IsWrapped && y > 0) {
+					nextLine = Buffer.Lines [--y];
+					wrappedLines.Insert (0, nextLine);
+				}
+
+				// If these lines contain the cursor don't touch them, the program will handle fixing up
+				// wrapped lines with the cursor
+				int absoluteY = Buffer.YBase + Buffer.Y;
+
+				if (absoluteY >= y && absoluteY < y + wrappedLines.Count) {
+					continue;
+				}
+
+				int lastLineLength = wrappedLines [wrappedLines.Count - 1].GetTrimmedLength ();
+				int [] destLineLengths = GetNewLineLengths (wrappedLines, oldCols, newCols);
+				int linesToAdd = destLineLengths.Length - wrappedLines.Count;
+
+				int trimmedLines;
+				if (Buffer.YBase == 0 && Buffer.Y != Buffer.Lines.Length - 1) {
+					// If the top section of the buffer is not yet filled
+					trimmedLines = Math.Max (0, Buffer.Y - Buffer.Lines.MaxLength + linesToAdd);
+				} else {
+					trimmedLines = Math.Max (0, Buffer.Lines.Length - Buffer.Lines.MaxLength + linesToAdd);
+				}
+
+				// Add the new lines
+				List<BufferLine> newLines = new List<BufferLine> ();
+				for (int i = 0; i < linesToAdd; i++) {
+					BufferLine newLine = Buffer.GetBlankLine (CharData.DefaultAttr, true);
+					newLines.Add (newLine);
+				}
+
+				if (newLines.Count > 0) {
+					toInsert.Add (new InsertionSet {
+						Start = y + wrappedLines.Count + countToInsert,
+						Lines = newLines.ToArray ()
+					});
+
+					countToInsert += newLines.Count;
+				}
+
+				newLines.ForEach (l => wrappedLines.Add (l));
+
+				// Copy buffer data to new locations, this needs to happen backwards to do in-place
+				int destLineIndex = destLineLengths.Length - 1; // Math.floor(cellsNeeded / newCols);
+				int destCol = destLineLengths [destLineIndex]; // cellsNeeded % newCols;
+				if (destCol == 0) {
+					destLineIndex--;
+					destCol = destLineLengths [destLineIndex];
+				}
+
+				int srcLineIndex = wrappedLines.Count - linesToAdd - 1;
+				int srcCol = lastLineLength;
+				while (srcLineIndex >= 0) {
+					int cellsToCopy = Math.Min (srcCol, destCol);
+					wrappedLines [destLineIndex].CopyCellsFrom (wrappedLines [srcLineIndex], srcCol - cellsToCopy, destCol - cellsToCopy, cellsToCopy);
+					destCol -= cellsToCopy;
+					if (destCol == 0) {
+						destLineIndex--;
+						if (destLineIndex >= 0)
+							destCol = destLineLengths [destLineIndex];
+					}
+
+					srcCol -= cellsToCopy;
+					if (srcCol == 0) {
+						srcLineIndex--;
+						int wrappedLinesIndex = Math.Max (srcLineIndex, 0);
+						srcCol = GetWrappedLineTrimmedLength (wrappedLines, wrappedLinesIndex, oldCols);
+					}
+				}
+
+				// Null out the end of the line ends if a wide character wrapped to the following line
+				for (int i = 0; i < wrappedLines.Count; i++) {
+					if (destLineLengths [i] < newCols) {
+						wrappedLines [i] [destLineLengths [i]] = CharData.Null;
+					}
+				}
+
+				// Adjust viewport as needed
+				int viewportAdjustments = linesToAdd - trimmedLines;
+				while (viewportAdjustments-- > 0) {
+					if (Buffer.YBase == 0) {
+						if (Buffer.Y < newRows - 1) {
+							Buffer.Y++;
+							Buffer.Lines.Pop ();
+						} else {
+							Buffer.YBase++;
+							Buffer.YDisp++;
+						}
+					} else {
+						// Ensure ybase does not exceed its maximum value
+						if (Buffer.YBase < Math.Min (Buffer.Lines.MaxLength, Buffer.Lines.Length + countToInsert) - newRows) {
+							if (Buffer.YBase == Buffer.YDisp) {
+								Buffer.YDisp++;
+							}
+
+							Buffer.YBase++;
+						}
+					}
+				}
+
+				Buffer.SavedY = Math.Min (Buffer.SavedY + linesToAdd, Buffer.YBase + newRows - 1);
+			}
+
+			Rearrange (toInsert, countToInsert);
+
+		}
+
+		void Rearrange (List<InsertionSet> toInsert, int countToInsert)
+		{
+			// Rearrange lines in the buffer if there are any insertions, this is done at the end rather
+			// than earlier so that it's a single O(n) pass through the buffer, instead of O(n^2) from many
+			// costly calls to CircularList.splice.
+			if (toInsert.Count > 0) {
+				// Record buffer insert events and then play them back backwards so that the indexes are
+				// correct
+				List<int> insertEvents = new List<int> ();
+
+				// Record original lines so they don't get overridden when we rearrange the list
+				CircularList<BufferLine> originalLines = new CircularList<BufferLine> (Buffer.Lines.MaxLength);
+				for (int i = 0; i < Buffer.Lines.Length; i++) {
+					originalLines.Push (Buffer.Lines [i]);
+				}
+
+				int originalLinesLength = Buffer.Lines.Length;
+
+				int originalLineIndex = originalLinesLength - 1;
+				int nextToInsertIndex = 0;
+				InsertionSet nextToInsert = toInsert [nextToInsertIndex];
+				Buffer.Lines.Length = Math.Min (Buffer.Lines.MaxLength, Buffer.Lines.Length + countToInsert);
+
+				int countInsertedSoFar = 0;
+				for (int i = Math.Min (Buffer.Lines.MaxLength - 1, originalLinesLength + countToInsert - 1); i >= 0; i--) {
+					if (!nextToInsert.IsNull && nextToInsert.Start > originalLineIndex + countInsertedSoFar) {
+						// Insert extra lines here, adjusting i as needed
+						for (int nextI = nextToInsert.Lines.Length - 1; nextI >= 0; nextI--) {
+							Buffer.Lines [i--] = nextToInsert.Lines [nextI];
+						}
+
+						i++;
+
+						// Create insert events for later
+						//insertEvents.Add ({
+						//	index: originalLineIndex + 1,
+						//	amount: nextToInsert.newLines.length
+						//});
+
+						countInsertedSoFar += nextToInsert.Lines.Length;
+						if (nextToInsertIndex < toInsert.Count - 1) {
+							nextToInsert = toInsert [++nextToInsertIndex];
+						} else {
+							nextToInsert = InsertionSet.Null;
+						}
+					} else {
+						Buffer.Lines [i] = originalLines [originalLineIndex--];
+					}
+				}
+
+				/*
+				// Update markers
+				let insertCountEmitted = 0;
+				for (let i = insertEvents.length - 1; i >= 0; i--) {
+					insertEvents [i].index += insertCountEmitted;
+					this.lines.onInsertEmitter.fire (insertEvents [i]);
+					insertCountEmitted += insertEvents [i].amount;
+				}
+
+				const amountToTrim = Math.max (0, originalLinesLength + countToInsert - this.lines.maxLength);
+				if (amountToTrim > 0) {
+					this.lines.onTrimEmitter.fire (amountToTrim);
+				}
+				*/
+			}
+		}
+
+		/// <summary>
+		/// Gets the new line lengths for a given wrapped line. The purpose of this function it to pre-
+		/// compute the wrapping points since wide characters may need to be wrapped onto the following line.
+		/// This function will return an array of numbers of where each line wraps to, the resulting array
+		/// will only contain the values `newCols` (when the line does not end with a wide character) and
+		/// `newCols - 1` (when the line does end with a wide character), except for the last value which
+		/// will contain the remaining items to fill the line.
+		/// Calling this with a `newCols` value of `1` will lock up.
+		/// </summary>
+		int [] GetNewLineLengths (List<BufferLine> wrappedLines, int oldCols, int newCols)
+		{
+			List<int> newLineLengths = new List<int> ();
+
+			int cellsNeeded = 0;
+			for (int i = 0; i < wrappedLines.Count; i++) {
+				cellsNeeded += GetWrappedLineTrimmedLength (wrappedLines, i, oldCols);
+			}
+
+			// Use srcCol and srcLine to find the new wrapping point, use that to get the cellsAvailable and
+			// linesNeeded
+			int srcCol = 0;
+			int srcLine = 0;
+			int cellsAvailable = 0;
+			while (cellsAvailable < cellsNeeded) {
+				if (cellsNeeded - cellsAvailable < newCols) {
+					// Add the final line and exit the loop
+					newLineLengths.Add (cellsNeeded - cellsAvailable);
+					break;
+				}
+
+				srcCol += newCols;
+				int oldTrimmedLength = GetWrappedLineTrimmedLength (wrappedLines, srcLine, oldCols);
+				if (srcCol > oldTrimmedLength) {
+					srcCol -= oldTrimmedLength;
+					srcLine++;
+				}
+
+				bool endsWithWide = wrappedLines [srcLine].GetWidth (srcCol - 1) == 2;
+				if (endsWithWide) {
+					srcCol--;
+				}
+
+				int lineLength = endsWithWide ? newCols - 1 : newCols;
+				newLineLengths.Add (lineLength);
+				cellsAvailable += lineLength;
+			}
+
+			return newLineLengths.ToArray ();
+		}
+
+		struct InsertionSet {
+			public BufferLine [] Lines;
+			public int Start;
+			public bool IsNull;
+			public static InsertionSet Null => new InsertionSet { IsNull = true };
+		}
+	}
+}

--- a/XtermSharp/ReflowStrategy.cs
+++ b/XtermSharp/ReflowStrategy.cs
@@ -1,0 +1,44 @@
+﻿using System.Collections.Generic;
+
+namespace XtermSharp {
+	abstract class ReflowStrategy {
+		protected ReflowStrategy (Buffer buffer)
+		{
+			this.Buffer = buffer;
+		}
+
+		public Buffer Buffer { get; }
+
+		public abstract void Reflow (int newCols, int newRows, int oldCols, int oldRows);
+
+		protected static int GetWrappedLineTrimmedLength (CircularList<BufferLine> lines, int row, int cols)
+		{
+			return GetWrappedLineTrimmedLength (lines [row], row == lines.Length - 1 ? null : lines [row + 1], cols);
+		}
+
+		protected static int GetWrappedLineTrimmedLength (List<BufferLine> lines, int row, int cols)
+		{
+			return GetWrappedLineTrimmedLength (lines [row], row == lines.Count - 1 ? null : lines [row+1], cols);
+		}
+
+		protected static int GetWrappedLineTrimmedLength (BufferLine line, BufferLine nextLine, int cols)
+		{
+			// If this is the last row in the wrapped line, get the actual trimmed length
+			if (nextLine == null) {
+				return line.GetTrimmedLength ();
+			}
+
+			// Detect whether the following line starts with a wide character and the end of the current line
+			// is null, if so then we can be pretty sure the null character should be excluded from the line
+			// length]
+			bool endsInNull = !(line.HasContent (cols - 1)) && line.GetWidth (cols - 1) == 1;
+			bool followingLineStartsWithWide = nextLine.GetWidth (0) == 2;
+
+			if (endsInNull && followingLineStartsWithWide) {
+				return cols - 1;
+			}
+
+			return cols;
+		}
+	}
+}

--- a/XtermSharp/ReflowWider.cs
+++ b/XtermSharp/ReflowWider.cs
@@ -1,0 +1,200 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace XtermSharp {
+	class ReflowWider : ReflowStrategy {
+		public ReflowWider (Buffer buffer) : base (buffer)
+		{
+		}
+
+		public override void Reflow (int newCols, int newRows, int oldCols, int oldRows)
+		{
+			int [] toRemove = GetLinesToRemove (Buffer.Lines, oldCols, newCols, Buffer.YBase + Buffer.Y, CharData.Null);
+			if (toRemove.Length > 0) {
+				LayoutResult newLayoutResult = CreateNewLayout (Buffer.Lines, toRemove);
+				ApplyNewLayout (Buffer.Lines, newLayoutResult.Layout);
+				AdjustViewport (newCols, newRows, newLayoutResult.RemovedCount);
+			}
+
+		}
+
+		/// <summary>
+		/// Evaluates and returns indexes to be removed after a reflow larger occurs. Lines will be removed
+		/// when a wrapped line unwraps.
+		/// </summary>
+		/// <param name="lines">The buffer lines</param>
+		/// <param name="oldCols">The columns before resize</param>
+		/// <param name="newCols">The columns after resize</param>
+		/// <param name="bufferAbsoluteY"></param>
+		/// <param name="nullCharacter"></param>
+		int [] GetLinesToRemove (CircularList<BufferLine> lines, int oldCols, int newCols, int bufferAbsoluteY, CharData nullCharacter)
+		{
+			// Gather all BufferLines that need to be removed from the Buffer here so that they can be
+			// batched up and only committed once
+			List<int> toRemove = new List<int> ();
+
+			for (int y = 0; y < lines.Length - 1; y++) {
+				// Check if this row is wrapped
+				int i = y;
+				BufferLine nextLine = lines [++i];
+				if (!nextLine.IsWrapped) {
+					continue;
+				}
+
+				// Check how many lines it's wrapped for
+				List<BufferLine> wrappedLines = new List<BufferLine> (lines.Length - y);
+				wrappedLines.Add (lines [y]);
+				while (i < lines.Length && nextLine.IsWrapped) {
+					wrappedLines.Add (nextLine);
+					nextLine = lines [++i];
+				}
+
+				// If these lines contain the cursor don't touch them, the program will handle fixing up wrapped
+				// lines with the cursor
+				if (bufferAbsoluteY >= y && bufferAbsoluteY < i) {
+					y += wrappedLines.Count - 1;
+					continue;
+				}
+
+				// Copy buffer data to new locations
+				int destLineIndex = 0;
+				int destCol = GetWrappedLineTrimmedLength (Buffer.Lines, destLineIndex, oldCols);
+				int srcLineIndex = 1;
+				int srcCol = 0;
+				while (srcLineIndex < wrappedLines.Count) {
+					int srcTrimmedTineLength = GetWrappedLineTrimmedLength (wrappedLines, srcLineIndex, oldCols);
+					int srcRemainingCells = srcTrimmedTineLength - srcCol;
+					int destRemainingCells = newCols - destCol;
+					int cellsToCopy = Math.Min (srcRemainingCells, destRemainingCells);
+
+					wrappedLines [destLineIndex].CopyCellsFrom (wrappedLines [srcLineIndex], srcCol, destCol, cellsToCopy);
+
+					destCol += cellsToCopy;
+					if (destCol == newCols) {
+						destLineIndex++;
+						destCol = 0;
+					}
+
+					srcCol += cellsToCopy;
+					if (srcCol == srcTrimmedTineLength) {
+						srcLineIndex++;
+						srcCol = 0;
+					}
+
+					// Make sure the last cell isn't wide, if it is copy it to the current dest
+					if (destCol == 0 && destLineIndex != 0) {
+						if (wrappedLines [destLineIndex - 1].GetWidth (newCols - 1) == 2) {
+							wrappedLines [destLineIndex].CopyCellsFrom (wrappedLines [destLineIndex - 1], newCols - 1, destCol++, 1);
+							// Null out the end of the last row
+							wrappedLines [destLineIndex - 1].ReplaceCells (newCols - 1, 1, nullCharacter);
+						}
+					}
+				}
+
+				// Clear out remaining cells or fragments could remain;
+				wrappedLines [destLineIndex].ReplaceCells (destCol, newCols, nullCharacter);
+
+				// Work backwards and remove any rows at the end that only contain null cells
+				int countToRemove = 0;
+				for (int ix = wrappedLines.Count - 1; ix > 0; ix--) {
+					if (ix > destLineIndex || wrappedLines [ix].GetTrimmedLength () == 0) {
+						countToRemove++;
+					} else {
+						break;
+					}
+				}
+
+				if (countToRemove > 0) {
+					toRemove.Add (y + wrappedLines.Count - countToRemove); // index
+					toRemove.Add (countToRemove);
+				}
+
+				y += wrappedLines.Count - 1;
+			}
+
+			return toRemove.ToArray ();
+		}
+
+		LayoutResult CreateNewLayout (CircularList<BufferLine> lines, int [] toRemove)
+		{
+			var layout = new CircularList<int> (lines.Length);
+
+			// First iterate through the list and get the actual indexes to use for rows
+			int nextToRemoveIndex = 0;
+			int nextToRemoveStart = toRemove [nextToRemoveIndex];
+			int countRemovedSoFar = 0;
+
+			for (int i = 0; i < lines.Length; i++) {
+				if (nextToRemoveStart == i) {
+					int countToRemove = toRemove [++nextToRemoveIndex];
+
+					// Tell markers that there was a deletion
+					//lines.onDeleteEmitter.fire ({
+					//	index: i - countRemovedSoFar,
+					//	amount: countToRemove
+					//});
+
+					i += countToRemove - 1;
+					countRemovedSoFar += countToRemove;
+
+					nextToRemoveStart = int.MaxValue;
+					if (nextToRemoveIndex < toRemove.Length - 1)
+						nextToRemoveStart = toRemove [++nextToRemoveIndex];
+				} else {
+					layout.Push (i);
+				}
+			}
+
+			return new LayoutResult () {
+				Layout = layout.ToArray (),
+				RemovedCount = countRemovedSoFar,
+			};
+		}
+
+		void ApplyNewLayout (CircularList<BufferLine> lines, int [] newLayout)
+		{
+			var newLayoutLines = new CircularList<BufferLine> (lines.Length);
+
+			for (int i = 0; i < newLayout.Length; i++) {
+				newLayoutLines.Push (lines [newLayout [i]]);
+			}
+
+			// Rearrange the list
+			for (int i = 0; i < newLayoutLines.Length; i++) {
+				lines [i] = newLayoutLines [i];
+			}
+
+			lines.Length = newLayout.Length;
+		}
+
+		void AdjustViewport (int newCols, int newRows, int countRemoved)
+		{
+			int viewportAdjustments = countRemoved;
+			while (viewportAdjustments-- > 0) {
+				if (Buffer.YBase == 0) {
+					if (Buffer.Y > 0) {
+						Buffer.Y--;
+					}
+
+					if (Buffer.Lines.Length < newRows) {
+						// Add an extra row at the bottom of the viewport
+						Buffer.Lines.Push (new BufferLine (newCols, CharData.Null));
+					}
+				} else {
+					if (Buffer.YDisp == Buffer.YBase) {
+						Buffer.YDisp--;
+					}
+
+					Buffer.YBase--;
+				}
+			}
+
+			Buffer.SavedY = Math.Max (Buffer.SavedY - countRemoved, 0);
+		}
+
+		struct LayoutResult {
+			public int [] Layout;
+			public int RemovedCount;
+		}
+	}
+}

--- a/XtermSharp/SelectionService.cs
+++ b/XtermSharp/SelectionService.cs
@@ -1,0 +1,198 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Text;
+
+namespace XtermSharp {
+	/// <summary>
+	/// Provides a service for working with selections
+	/// </summary>
+	public class SelectionService {
+		readonly PointComparer comparer;
+		readonly Terminal terminal;
+		private bool active;
+
+		public SelectionService (Terminal terminal)
+		{
+			this.terminal = terminal;
+			comparer = new PointComparer ();
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the selection is active or not
+		/// </summary>
+		public bool Active {
+			get => active;
+			set {
+				var oldState = active;
+				active = value;
+				if (oldState != value) {
+					SelectionChanged?.Invoke ();
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets the selection start point in buffer coordinates
+		/// </summary>
+		public Point Start { get; private set; }
+
+		/// <summary>
+		/// Gets or sets the selection end point in buffer coordinates
+		/// </summary>
+		public Point End { get; private set; }
+
+		/// <summary>
+		/// Raised when the selection range or active state has been changed
+		/// </summary>
+		public event Action SelectionChanged;
+
+		/// <summary>
+		/// Starts selection from the given point in the buffer
+		/// </summary>
+		public void StartSelection (int row, int col)
+		{
+			Start = End = new Point (col, row + terminal.Buffer.YDisp);
+			// set the field to bypass sending this event twice
+			active = true;
+			SelectionChanged?.Invoke ();
+		}
+
+		/// <summary>
+		/// Starts selection from the last start position
+		/// </summary>
+		public void StartSelection ()
+		{
+			End = Start;
+			// set the field to bypass sending this event twice
+			active = true;
+			SelectionChanged?.Invoke ();
+		}
+
+		/// <summary>
+		/// Sets the start and end positions but does not start selection
+		/// this lets us record the last position of mouse clicks so that
+		/// drag and shift+click operations know from where to start selection
+		/// from
+		/// </summary>
+		public void SetSoftStart(int row, int col)
+		{
+			Start = End = new Point (col, row + terminal.Buffer.YDisp);
+		}
+
+		/// <summary>
+		/// Extends the selection based on the user "shift" clicking. This has
+		/// slightly different semantics than a "drag" extension because we can
+		/// shift the start to be the last prior end point if the new extension
+		/// is before the current start point. 
+		/// </summary>
+		public void ShiftExtend (int row, int col)
+		{
+			active = true;
+			var newEnd = new Point (col, row + terminal.Buffer.YDisp);
+
+			var shouldSwapStart = false;
+			if (comparer.Compare (Start, End) < 0) {
+				// start is before end, is the new end before Start
+				if (comparer.Compare (newEnd, Start) < 0) {
+					// yes, swap Start and End
+					shouldSwapStart = true;
+				}
+			} else if (comparer.Compare (Start, End) > 0) {
+				if (comparer.Compare (newEnd, Start) > 0) {
+					// yes, swap Start and End
+					shouldSwapStart = true;
+				}
+			}
+
+			if (shouldSwapStart) {
+				Start = End;
+			}
+
+			End = newEnd;
+			SelectionChanged?.Invoke ();
+		}
+
+		/// <summary>
+		/// Extends the selection by moving the end point to the new point.
+		/// </summary>
+		public void DragExtend (int row, int col)
+		{
+			End = new Point (col, row + terminal.Buffer.YDisp);
+			SelectionChanged?.Invoke ();
+		}
+
+		public string GetSelectedText ()
+		{
+			var start = Start;
+			var end = End;
+
+			switch (comparer.Compare (start, End)) {
+			case 0:
+				return string.Empty;
+			case 1:
+				start = End;
+				end = Start;
+				break;
+			}
+
+			var nullStr = NStack.ustring.Make (CharData.Null.Rune);
+			var spaceStr = NStack.ustring.Make (" ");
+
+			var builder = new StringBuilder ();
+
+			// get the first line
+			BufferLine bufferLine = null;
+			var str = terminal.Buffer.TranslateBufferLineToString (start.Y, true, start.X, start.Y < end.Y ? -1 : end.X).Replace (nullStr, spaceStr);
+			builder.Append (str.ToString ());
+
+			// get the middle rows
+			var line = start.Y + 1;
+			var isWrapped = false;
+			while (line < end.Y) {
+				bufferLine = terminal.Buffer.Lines [line];
+				isWrapped = bufferLine?.IsWrapped ?? false;
+
+				str = terminal.Buffer.TranslateBufferLineToString (line, true, 0, -1).Replace (nullStr, spaceStr);
+
+				if (!isWrapped)
+					builder.AppendLine ();
+
+				builder.Append (str.ToString ());
+
+				line++;
+			}
+
+			if (end.Y != start.Y) {
+				// get the last row
+				bufferLine = terminal.Buffer.Lines [end.Y];
+				isWrapped = bufferLine?.IsWrapped ?? false;
+				str = terminal.Buffer.TranslateBufferLineToString (end.Y, true, 0, end.X).Replace (nullStr, spaceStr);
+				if (!isWrapped) {
+					builder.AppendLine ();
+				}
+
+				builder.Append (str.ToString ());
+			}
+
+			return builder.ToString ();
+		}
+
+		class PointComparer : IComparer<Point> {
+			public int Compare (Point x, Point y)
+			{
+				if (x.Y < y.Y)
+					return -1;
+				if (x.Y > y.Y)
+					return 1;
+				// x and y are on the same row, compare columns
+				if (x.X < y.X)
+					return -1;
+				if (x.X > y.X)
+					return 1;
+				// they are the same
+				return 0;
+			}
+		}
+	}
+}

--- a/XtermSharp/Terminal.cs
+++ b/XtermSharp/Terminal.cs
@@ -402,10 +402,12 @@ namespace XtermSharp {
 				rows = MINIMUM_ROWS;
 			if (cols == Cols && rows == Rows)
 				return;
+
+			var oldCols = Cols;
 			Cols = cols;
 			Rows = rows;
 			Buffers.Resize (cols, rows);
-			buffers.SetupTabStops (cols);
+			buffers.SetupTabStops (oldCols);
 			Refresh (0, Rows - 1);
 		}
 

--- a/XtermSharp/Terminal.cs
+++ b/XtermSharp/Terminal.cs
@@ -344,8 +344,7 @@ namespace XtermSharp {
 			 *
 			 * @event scroll
 			 */
-			if (Scrolled != null)
-				Scrolled (this, buffer.YDisp);
+			Scrolled?.Invoke (this, buffer.YDisp);
 		}
 
 		public event Action<Terminal, int> Scrolled;

--- a/XtermSharp/Utils/CircularList.cs
+++ b/XtermSharp/Utils/CircularList.cs
@@ -211,5 +211,15 @@ namespace XtermSharp {
 		}
 
 		public bool IsFull => Length == MaxLength;
+
+		public T[] ToArray()
+		{
+			var result = new T [Length];
+			for (int i = 0; i < Length; i++) {
+				result [i] = array [GetCyclicIndex (i)];
+			}
+
+			return result;
+		}
 	}
 }


### PR DESCRIPTION
basic support for scrolling, selection and copy+paste. there are several issues that should be resolved before this is merged, most significantly what to do with tabs and newlines when copying as these are not present in the buffer currently. there are a set of smaller "polish" items that I think should be done as well.

- [x] ~tab and~ newlines should be able to be copied from the buffer
- [x] buffer resize and reflow (related to tab/newlines issue). when the buffer changes we need to reflow the content and reposition soft breaks ~and tabs~
- [x] ~voice over support for the terminal view~
- [x] properly disable scrolling when alt buffer is enabled
- [x] restore scroll position when switching back from alt buffer
- [x] scroll thumb proportion is not correct
- [x] mouse wheel support for scrolling
- [x] scroll paging
- [x] select and scroll at the same time
- [x] cursor is not scrolled properly
- [x] delete stale log files rather than leaving them on disk
- [x] watch the shell process and disable/close the terminal window when the shell exits
- [x] selection should clear when the user types, switches to the alt buffer
- [x] selection logic could moved to a selection service
- [ ] profit

Voice over will be a different PR.
