### PR TITLE
Various fixes for the TerminalControl

### DIFF
--- a/MacTerminal/MacTerminal.csproj
+++ b/MacTerminal/MacTerminal.csproj
@@ -53,6 +53,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="Xamarin.Mac" />
+    <PackageReference Include="NStack.Core" Version="0.12.0" />
   </ItemGroup>
   <ItemGroup>
     <ImageAsset Include="Assets.xcassets\AppIcon.appiconset\Contents.json" />

--- a/XtermSharp.Mac/TerminalControl.cs
+++ b/XtermSharp.Mac/TerminalControl.cs
@@ -62,8 +62,8 @@ namespace XtermSharp.Mac {
 			var viewFrame = Frame;
 
 			var scrollWidth = NSScroller.ScrollerWidthForControlSize (NSControlSize.Regular);
-			var scrollFrame = new CGRect (viewFrame.Right - scrollWidth, viewFrame.Y, scrollWidth, viewFrame.Height);
-			viewFrame = new CGRect (viewFrame.X, viewFrame.Y, viewFrame.Width - scrollWidth, viewFrame.Height);
+			var scrollFrame = new CGRect (viewFrame.Right - scrollWidth, 0, scrollWidth, viewFrame.Height);
+			viewFrame = new CGRect (0, 0, viewFrame.Width - scrollWidth, viewFrame.Height);
 
 			scroller.Frame = scrollFrame;
 			terminalView.Frame = viewFrame;

--- a/XtermSharp.Mac/TerminalControl.cs
+++ b/XtermSharp.Mac/TerminalControl.cs
@@ -28,6 +28,12 @@ namespace XtermSharp.Mac {
 
 		public string ExitText { get; set; } = string.Empty;
 
+		public int ShellProcessId {
+			get	{
+				return shellPid;
+			}
+		}
+
 		/// <summary>
 		/// Raised when the title of the terminal has changed
 		/// </summary>

--- a/XtermSharp.Mac/TerminalControl.cs
+++ b/XtermSharp.Mac/TerminalControl.cs
@@ -41,7 +41,7 @@ namespace XtermSharp.Mac {
 		/// <summary>
 		/// Launches the shell
 		/// </summary>
-		public void StartShell(string shellPath = "/bin/bash", string [] args = null)
+		public void StartShell(string shellPath = "/bin/bash", string [] args = null, string [] env = null)
 		{
 			// TODO: throw error if already started
 			terminalView.Feed (WelcomeText + "\n");
@@ -53,7 +53,7 @@ namespace XtermSharp.Mac {
 			shellArgs [0] = shellPath;
 			args?.CopyTo (shellArgs, 1);
 
-			shellPid = Pty.ForkAndExec (shellPath, shellArgs, Terminal.GetEnvironmentVariables (), out shellFileDescriptor, size);
+			shellPid = Pty.ForkAndExec (shellPath, shellArgs, env ?? Terminal.GetEnvironmentVariables (), out shellFileDescriptor, size);
 			DispatchIO.Read (shellFileDescriptor, (nuint)readBuffer.Length, DispatchQueue.CurrentQueue, ChildProcessRead);
 		}
 

--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -896,7 +896,7 @@ namespace XtermSharp.Mac {
 
 		void CalculateMouseHit (NSEvent theEvent, bool down, out int col, out int row)
 		{
-			var point = theEvent.LocationInWindow;
+			var point = ConvertPointFromView (theEvent.LocationInWindow, null);
 			col = (int)(point.X / cellWidth);
 			row = (int)((Frame.Height - point.Y) / cellHeight);
 		}

--- a/XtermSharp.Mac/XtermSharp.Mac.csproj
+++ b/XtermSharp.Mac/XtermSharp.Mac.csproj
@@ -61,9 +61,6 @@
     <Compile Include="SelectionView.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\XtermSharp\XtermSharp.csproj">
       <Project>{218EB800-B5D6-46C3-8113-8DB312AE0C64}</Project>
       <Name>XtermSharp</Name>

--- a/XtermSharp.Mac/packages.config
+++ b/XtermSharp.Mac/packages.config
@@ -1,4 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="NStack.Core" version="0.12.0" targetFramework="xamarinmac20" />
-</packages>


### PR DESCRIPTION
 - Fix Mac app failing to find NStack on startup
 - Remove packages.config file which is not needed
 - Fix terminal selection being incorrect depending on host
 - Support environment variables being passed to terminal
 - TerminalControl provides the process id of the shell that was run
 - Fix exception sending user input to shell after process has exited 