### PR TITLE
Initial macOS voice over support

### DIFF
--- a/MacTerminal/Main.storyboard
+++ b/MacTerminal/Main.storyboard
@@ -652,7 +652,7 @@
         <scene sceneID="R2V-B0-nI4">
             <objects>
                 <windowController id="B8D-0N-5wS" sceneMemberID="viewController">
-                    <window key="window" title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
+                    <window key="window" title="XtermSharp" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="IQv-IB-iLA">
                         <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
                         <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
                         <rect key="contentRect" x="196" y="240" width="1024" height="768"/>

--- a/XtermSharp.Mac/AccessibilityService.cs
+++ b/XtermSharp.Mac/AccessibilityService.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace XtermSharp.Mac {
+	/// <summary>
+	/// Handles macOS accessibilty for the terminal view
+	/// </summary>
+	public class AccessibilityService {
+		readonly Terminal terminal;
+		readonly SelectionService selection;
+		AccessibilitySnapshot cache;
+
+		public AccessibilityService (Terminal terminal)
+		{
+			this.terminal = terminal;
+			this.selection = new SelectionService (terminal);
+
+			// TODO: handle terminal.Buffer.scrolled and handle lines being scrolled off the top of the buffer
+			// TODO: hook up events in terminal that lets us know when the buffer content has changed
+		}
+
+		public AccessibilitySnapshot GetSnapshot ()
+		{
+			if (cache == null) {
+				var result = CalculateSnapshot ();
+				cache = result;
+			}
+
+			return cache;
+		}
+
+		public void Invalidate ()
+		{
+			cache = null;
+		}
+
+		private AccessibilitySnapshot CalculateSnapshot ()
+		{
+			selection.SelectAll ();
+
+			// TODO: calc visible char range
+
+			var text = selection.GetSelectedText ();
+
+			// add a space at the end for the space between the prompt and the caret
+			if (terminal.Buffers.IsAlternateBuffer) {
+				text += " ";
+			}
+
+			int caret = CalculateCaretPosition(text);
+
+			AccessibilitySnapshot.Range visble = new AccessibilitySnapshot.Range { Start = 0, Length = text.Length };
+
+			var result = new AccessibilitySnapshot (text, visble, caret);
+
+			return result;
+		}
+
+		int CalculateCaretPosition(string text)
+		{
+			if (terminal.Buffers.IsAlternateBuffer) {
+				// TODO: alternate buffer support
+				return text.Length;
+			}
+
+			// when the normal buffer is active we always have the caret on the last row of text, somewhere along
+			// the line. Buffer.X is that position on the last row. We need to find the beginning of the last line
+			// of text
+			int lineStart = 0;
+			for (int i = text.Length - 1; i > 0; i--) {
+				if (text[i] == '\n') {
+					lineStart = i + 1;
+					break;
+				}
+			}
+
+			return lineStart + terminal.Buffer.X;
+		}
+	}
+
+	public class AccessibilitySnapshot {
+		public AccessibilitySnapshot (string text, Range visible, int caret)
+		{
+			Text = text;
+			VisibleRange = visible;
+			CaretPosition = caret;
+		}
+
+		public string Text { get; }
+
+		public Range VisibleRange { get; }
+
+		public int CaretPosition { get; }
+
+		[DebuggerDisplay("{Start}, {Length}")]
+		public struct Range {
+			public int Start;
+			public int Length;
+		}
+	}
+}

--- a/XtermSharp.Mac/XtermSharp.Mac.csproj
+++ b/XtermSharp.Mac/XtermSharp.Mac.csproj
@@ -59,6 +59,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="TerminalControl.cs" />
     <Compile Include="SelectionView.cs" />
+    <Compile Include="AccessibilityService.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/XtermSharp/Buffer.cs
+++ b/XtermSharp/Buffer.cs
@@ -236,9 +236,14 @@ namespace XtermSharp {
 		/// <param name="endCol">The column to end at.</param>
 		public ustring TranslateBufferLineToString (int lineIndex, bool trimRight, int startCol = 0, int endCol = -1)
 		{
-			var line = lines [lineIndex];
+			try {
+				var line = lines [lineIndex];
 
-			return line.TranslateToString (trimRight, startCol, endCol);
+				return line.TranslateToString (trimRight, startCol, endCol);
+			} catch ( Exception ex)
+			{
+				return ustring.Empty;
+			}
 		}
 
 		/// <summary>

--- a/XtermSharp/BufferLine.cs
+++ b/XtermSharp/BufferLine.cs
@@ -45,7 +45,16 @@ namespace XtermSharp {
 		   * from real empty cells.
 		   * */
 		   // TODO: not sue this is completely right
-		public bool HasContent (int index) => data [index].Code != 0 && data [index].Attribute != CharData.DefaultAttr;
+		public bool HasContent (int index) => data [index].Code != 0 || data [index].Attribute != CharData.DefaultAttr;
+
+		public bool HasAnyContent()
+		{
+			for (int i = 0; i < data.Length; i++) {
+				if (HasContent (i)) return true;
+			}
+
+			return false;
+		}
 
 		string DebuggerDisplay {
 			get {


### PR DESCRIPTION
- implemented BufferLine.HasAnyContent so that we can skip trailing blank
  lines when getting selected text
- implemented SelectAll in selection service
- ensure that the caret is visible when the user types
- implemented initial macOS voice over support.

Voice over will read the contents of the terminal when focused and will
announce text as typed as well as new content as a result of a command