### PR TITLE
Update the caret when the terminal is focused/defocused

### DIFF
--- a/XtermSharp.Mac/CaretView.cs
+++ b/XtermSharp.Mac/CaretView.cs
@@ -1,0 +1,52 @@
+﻿using AppKit;
+using CoreGraphics;
+
+namespace XtermSharp.Mac {
+	class CaretView : NSView {
+		NSColor caretColor;
+		bool focused;
+
+		public CaretView (CGRect rect) : base (rect)
+		{
+			WantsLayer = true;
+		}
+
+		/// <summary>
+		/// Gets or sets the color used to show selection
+		/// </summary>
+		public NSColor CaretColor {
+			get => caretColor;
+			set {
+				caretColor = value;
+				Layer.BorderColor = caretColor.CGColor;
+				if (Focused) {
+					Layer.BackgroundColor = caretColor.CGColor;
+					Layer.BorderWidth = 0;
+				} else {
+					Layer.BorderWidth = 1;
+				}
+			}
+		}
+
+		/// <summary>
+		/// Gets or sets a value indicating whether the caret should show focused or non-focused
+		/// </summary>
+		public bool Focused {
+			get {
+				return focused;
+			}
+			set {
+				focused = value;
+				if (value) {
+					Layer.BackgroundColor = caretColor.CGColor;
+					Layer.BorderWidth = 0;
+
+				} else {
+					Layer.BackgroundColor = NSColor.Clear.CGColor;
+					Layer.BorderWidth = 2;
+
+				}
+			}
+		}
+	}
+}

--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -23,7 +23,7 @@ namespace XtermSharp.Mac {
 		readonly Terminal terminal;
 		readonly SelectionService selection;
 		readonly AccessibilityService accessibility;
-		readonly NSView caret, debug;
+		readonly CaretView caret;
 		readonly SelectionView selectionView;
 		readonly NSFont fontNormal, fontItalic, fontBold, fontBoldItalic;
 		readonly Timer autoScrollTimer = new Timer (80);
@@ -52,20 +52,12 @@ namespace XtermSharp.Mac {
 				SelectionColor = selectColor,
 			};
 
-			caret = new NSView (new CGRect (0, cellDelta, cellHeight, cellWidth)) {
-				WantsLayer = true
-			};
+			caret = new CaretView (new CGRect (0, cellDelta, cellHeight, cellWidth)) { Focused = false };
 			AddSubview (caret);
-			debug = new NSView (new CGRect (0, 0, 10, 10)) {
-				WantsLayer = true
-			};
-			//AddSubview (debug);
 
 			var caretColor = NSColor.FromColor (NSColor.Blue.ColorSpace, 0.4f, 0.2f, 0.9f, 0.5f);
 
-			caret.Layer.BackgroundColor = caretColor.CGColor;
-
-			debug.Layer.BackgroundColor = caretColor.CGColor;
+			caret.CaretColor = caretColor;
 
 			terminal.Scrolled += Terminal_Scrolled;
 			terminal.Buffers.Activated += Buffers_Activated;
@@ -808,7 +800,14 @@ namespace XtermSharp.Mac {
 		[Export ("selectedRange")]
 		public NSRange SelectedRange => notFoundRange;
 
-		public bool HasFocus { get; private set; }
+		bool hasFocus;
+		public bool HasFocus {
+			get { return hasFocus; }
+			private set {
+				hasFocus = value;
+				caret.Focused = value;
+			}
+		}
 
 		[Export ("attributedSubstringForProposedRange:actualRange:")]
 		public NSAttributedString AttributedSubstringForProposedRange (NSRange range, out NSRange actualRange)

--- a/XtermSharp.Mac/XtermSharp.Mac.csproj
+++ b/XtermSharp.Mac/XtermSharp.Mac.csproj
@@ -60,6 +60,7 @@
     <Compile Include="TerminalControl.cs" />
     <Compile Include="SelectionView.cs" />
     <Compile Include="AccessibilityService.cs" />
+    <Compile Include="CaretView.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />


### PR DESCRIPTION
Changes the shape of the caret when the view is not the first responder. Doesn't handle when the application is not active yet.

![Screen Recording 2020-02-27 at 04 02 PM](https://user-images.githubusercontent.com/723721/75486479-94781000-597a-11ea-969e-da36085bc200.gif)

