### PR TITLE
Support device status (get cursor location)

### DIFF
--- a/XtermSharp.Mac/TerminalControl.cs
+++ b/XtermSharp.Mac/TerminalControl.cs
@@ -117,6 +117,8 @@ namespace XtermSharp.Mac {
 			};
 
 			AddSubview (terminalView);
+
+			t.DataEmitted += HandleTerminalDataEmitted;
 		}
 
 		void HandleTerminalScrolled (double scrollPosition)
@@ -162,6 +164,12 @@ namespace XtermSharp.Mac {
 			// TODO: log result of SetWinSize if != 0
 
 			UpdateScroller ();
+		}
+
+		void HandleTerminalDataEmitted (Terminal terminal, string txt)
+		{
+			var data = System.Text.Encoding.UTF8.GetBytes (txt);
+			DispatchIO.Write (shellFileDescriptor, DispatchData.FromByteBuffer (data), DispatchQueue.CurrentQueue, ChildProcessWrite);
 		}
 
 		void UpdateScroller()

--- a/XtermSharp/InputHandler.cs
+++ b/XtermSharp/InputHandler.cs
@@ -720,7 +720,7 @@ namespace XtermSharp {
 		// 
 		void DeviceStatus (int [] pars, string collect)
 		{
-			if (collect != "") {
+			if (collect == "") {
 				switch (pars [0]) {
 				case 5:
 					// status report
@@ -730,7 +730,7 @@ namespace XtermSharp {
 					// cursor position
 					var y = terminal.Buffer.Y + 1;
 					var x = terminal.Buffer.X + 1;
-					terminal.EmitData ($"$\x1b[${y};${x}R");
+					terminal.EmitData ($"\x1b[{y};{x}R");
 					break;
 				}
 			} else if (collect == "?") {
@@ -741,7 +741,7 @@ namespace XtermSharp {
 					// cursor position
 					var y = terminal.Buffer.Y + 1;
 					var x = terminal.Buffer.X + 1;
-					terminal.EmitData ($"$\x1b[?${y};${x}R");
+					terminal.EmitData ($"\x1b[?{y};{x}R");
 					break;
 				case 15:
 					// no printer

--- a/XtermSharp/Terminal.cs
+++ b/XtermSharp/Terminal.cs
@@ -349,6 +349,8 @@ namespace XtermSharp {
 
 		public event Action<Terminal, int> Scrolled;
 
+		public event Action<Terminal, string> DataEmitted;
+
 		internal void Bell ()
 		{
 			//Console.WriteLine ("beep");
@@ -584,7 +586,7 @@ namespace XtermSharp {
 
 		internal void EmitData (string txt)
 		{
-			throw new NotImplementedException ();
+			DataEmitted?.Invoke (this, txt);
 		}
 
 		/// <summary>


### PR DESCRIPTION
Handes the case where mono will clear the screen on a Console.ReadKey.

Console app output is cleared when Console.ReadKey is used
    - .NET Core console projects are OK
    - Only affects console projects run with Mono. Can reproduce the problem in the Terminal directly by running `mono console-project.exe`
    - XtermSharp is erasing the display since it seems to get an escape code to do that - [callstack](https://gist.github.com/mrward/1925e3a7f163146e128e8c84373d9ed9) - ESC (27) [ (91) number of rows (50=2 => clear entire screen) J (74 = Erase in display) - Mono asks the terminal host for the [cursor position](https://github.com/mono/mono/blob/54703867754ae6be00d5b63dfb36a9413abfa53e/mcs/class/corlib/System/TermInfoDriver.cs#L461), if none is returned it sends a [clear display escape code](https://github.com/mono/mono/blob/54703867754ae6be00d5b63dfb36a9413abfa53e/mcs/class/corlib/System/TermInfoDriver.cs#L264).

There appeared to be 3 issues, the first being that the code path when querying device status never hits any of the methods that return a value. `collect` always appears to be an empty string (or might be a "?" for different shells). The second issue is that the wrong string is returned, looks like a copy from javascript template literals including an extra "$". The 3rd issue is that xterm.js "OnData" is not implemented.