### PR TITLE
Fix crash when resizing.

### DIFF
--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -358,6 +358,8 @@ namespace XtermSharp.Mac {
 			var res = new NSMutableAttributedString ();
 			int attr = 0;
 
+			cols = Math.Min (cols, line.Length);
+
 			basBuilder.Clear ();
 			for (int col = 0; col < cols; col++) {
 				var ch = line [col];

--- a/XtermSharp/Buffer.cs
+++ b/XtermSharp/Buffer.cs
@@ -133,7 +133,7 @@ namespace XtermSharp {
 			if (this.lines.Length > 0) {
 				// Deal with columns increasing (reducing needs to happen after reflow)
 				if (cols < newCols) {
-					for (int i = 0; i < lines.Length; i++) {
+					for (int i = 0; i < lines.MaxLength; i++) {
 						lines [i]?.Resize (newCols, CharData.Null);
 					}
 				}
@@ -215,7 +215,7 @@ namespace XtermSharp {
 
 				// Trim the end of the line off if cols shrunk
 				if (cols > newCols) {
-					for (int i = 0; i < lines.Length; i++) {
+					for (int i = 0; i < lines.MaxLength; i++) {
 						lines [i]?.Resize (newCols, CharData.Null);
 					}
 				}


### PR DESCRIPTION
When the user resizes the view a number of times, both vertically and horizontally, the
terminal resizes the length of the lines and leave lines after `length` unadjusted.

This lets the buffer lines get into a state where there are lines that are
not sized correctly because they are after the point in the buffer at which terminal
thinks there is valid content. This seems to be valid, the issue I believe is
that the the view updates the display it does not take into account the length
of Buffer.Lines.

Maybe TerminalView should take into account the length of Buffer.Lines, but
having the lines different and randomly different lengths in the array is also
confusing when debugging and this isn't that much more expensive (since after the
first full page of lines Length will start to approach MaxLength anyway).