### PR TITLE
Disable HitTest on caret and selection views

### DIFF
--- a/XtermSharp.Mac/CaretView.cs
+++ b/XtermSharp.Mac/CaretView.cs
@@ -96,6 +96,12 @@ namespace XtermSharp.Mac {
 			}
 		}
 
+		public override NSView HitTest (CGPoint aPoint)
+		{
+			// we do not want to steal hits, let the terminal view take them
+			return null;
+		}
+
 		void UpdateMask ()
 		{
 			// remove the prior mask

--- a/XtermSharp.Mac/SelectionView.cs
+++ b/XtermSharp.Mac/SelectionView.cs
@@ -78,6 +78,12 @@ namespace XtermSharp.Mac {
 			base.Dispose (disposing);
 		}
 
+		public override NSView HitTest (CGPoint aPoint)
+		{
+			// we do not want to steal hits, let the terminal view take them
+			return null;
+		}
+
 		void HandleSelectionChanged ()
 		{
 			UpdateMask ();


### PR DESCRIPTION
This prevents these subviews from stealing mouse hits which are preventing
the terminal view from becoming first responder with mouse down.