### PR TITLE
Context menu hooks

### DIFF
--- a/XtermSharp.Mac/ProcessTerminalView.cs
+++ b/XtermSharp.Mac/ProcessTerminalView.cs
@@ -88,9 +88,9 @@ namespace XtermSharp.Mac {
 		{
 			var terminalFrame = Bounds;
 
-			terminalView = new TerminalView (terminalFrame);
+			terminalView = OnCreateTerminalView (terminalFrame);
 			var t = terminalView.Terminal;
-
+			
 			terminalView.UserInput = HandleUserInput;
 			terminalView.SizeChanged += HandleSizeChanged;
 			terminalView.TitleChanged += HandleTitleChanged;
@@ -98,6 +98,13 @@ namespace XtermSharp.Mac {
 			AddSubview (terminalView);
 
 			t.DataEmitted += HandleTerminalDataEmitted;
+		}
+
+		protected virtual TerminalView OnCreateTerminalView (CGRect terminalFrame)
+		{
+			// temp logic for allowing for a different terminal view
+			// I think the best solution is to make ProcessTerminalView a subclass of TerminalView
+			return new TerminalView (terminalFrame);
 		}
 
 		void HandleTerminalDataEmitted (Terminal terminal, string txt)

--- a/XtermSharp.Mac/TerminalView.cs
+++ b/XtermSharp.Mac/TerminalView.cs
@@ -1198,7 +1198,7 @@ namespace XtermSharp.Mac {
 				if (!didSelectionDrag) {
 					if (theEvent.ModifierFlags.HasFlag (NSEventModifierMask.ShiftKeyMask)) {
 						selection.ShiftExtend (row, col);
-					} else {
+					} else if (!theEvent.ModifierFlags.HasFlag (NSEventModifierMask.ControlKeyMask)) {
 						selection.Active = false;
 						selection.SetSoftStart (row, col);
 					}
@@ -1206,6 +1206,19 @@ namespace XtermSharp.Mac {
 			}
 
 			didSelectionDrag = false;
+
+			if (theEvent.ModifierFlags.HasFlag (NSEventModifierMask.ControlKeyMask)) {
+				OnShowContextMenu (theEvent);
+			}
+		}
+
+		public override void RightMouseUp (NSEvent theEvent)
+		{
+			OnShowContextMenu (theEvent);
+		}
+
+		protected virtual void OnShowContextMenu(NSEvent theEvent)
+		{
 		}
 
 		public override void MouseDragged (NSEvent theEvent)


### PR DESCRIPTION
- Provide a temporary hook to allow ProcessTerminalView subclasses to inject a different TerminalView	a7de27c	Greg Munn <gregm@microsoft.com>	Mar 27, 2020 at 9:24 AM
- Provide hooks for subclasses of TerminalView to show their own context menu