### PR TITLE
Fixes a crash when reflowing narrower and content needs to be pushed out the "top" of the buffer.

### DIFF
--- a/Tests/BufferTests/ReflowNarrowerTest.cs
+++ b/Tests/BufferTests/ReflowNarrowerTest.cs
@@ -1,0 +1,25 @@
+using System;
+using XtermSharp;
+using Xunit;
+
+namespace XtermSharp.Tests.BufferTests {
+
+	public class ReflowNarrowerTests {
+		[Fact]
+		public void DoesNotCrashWhenReflowingToTinyWidth ()
+		{
+			var options = new TerminalOptions () { Cols = 10, Rows = 10 };
+			options.Scrollback = 1;
+			var terminal = new Terminal (null, options);
+
+			terminal.Feed ("1234567890\r\n");
+			terminal.Feed ("ABCDEFGH\r\n");
+			terminal.Feed ("abcdefghijklmnopqrstxxx\r\n");
+			terminal.Feed ("\r\n");
+
+			// if we resize to a small column width, content is pushed back up and out the top
+			// of the buffer. Ensure that this does not crash
+			terminal.Resize (3, 10);
+		}
+	}
+}

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -17,5 +17,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="EscTests\" />
+    <Folder Include="BufferTests\" />
   </ItemGroup>
 </Project>

--- a/XtermSharp/ReflowNarrower.cs
+++ b/XtermSharp/ReflowNarrower.cs
@@ -162,6 +162,12 @@ namespace XtermSharp {
 					if (!nextToInsert.IsNull && nextToInsert.Start > originalLineIndex + countInsertedSoFar) {
 						// Insert extra lines here, adjusting i as needed
 						for (int nextI = nextToInsert.Lines.Length - 1; nextI >= 0; nextI--) {
+							if (i < 0) {
+								// if we reflow and the content has to be scrolled back past the beginning
+								// of the buffer then we end up loosing those lines
+								break;
+							}
+
 							Buffer.Lines [i--] = nextToInsert.Lines [nextI];
 						}
 

--- a/XtermSharp/TerminalOptions.cs
+++ b/XtermSharp/TerminalOptions.cs
@@ -10,8 +10,8 @@ namespace XtermSharp {
 		public string TermName;
 		public CursorStyle CursorStyle;
 		public bool ScreenReaderMode;
-		public int? Scrollback { get; }
-		public int? TabStopWidth { get; }
+		public int? Scrollback { get; set; }
+		public int? TabStopWidth { get; set; }
 
 		public TerminalOptions ()
 		{


### PR DESCRIPTION
This appears to happen when we are near the end of the buffer (including
scrollback) and content needs to be squished and overflows out the top
of the buffer. Possible enhancements in the future might be to increase
the scrollback and shift the content but this fixes the immediate crash.

```
XtermSharp.CircularList`1[[XtermSharp.BufferLine, XtermSharp, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null]].set_Item(Int32,BufferLine)
XtermSharp.ReflowNarrower.Rearrange(List`1,Int32)
XtermSharp.ReflowNarrower.Reflow(Int32,Int32,Int32,Int32)
XtermSharp.Buffer.Reflow(Int32,Int32)
XtermSharp.Buffer.Resize(Int32,Int32)
XtermSharp.BufferSet.Resize(Int32,Int32)
XtermSharp.Terminal.Resize(Int32,Int32)
```