### PR TITLE
Fixes a crash when selecting word or expression

### DIFF
--- a/Tests/BufferTests/SelectionTests.cs
+++ b/Tests/BufferTests/SelectionTests.cs
@@ -1,0 +1,32 @@
+﻿using Xunit;
+
+namespace XtermSharp.Tests.BufferTests {
+	public class SelectionTests {
+		[Fact]
+		public void DoesNotCrashWhenSelectingWordOrExpressionOutsideColumnRange ()
+		{
+			var terminal = new Terminal (null, new TerminalOptions { Rows = 10, Cols = 10 });
+			var selection = new SelectionService (terminal);
+
+			terminal.Feed ("1234567890");
+
+			// depending on the size of terminal view, there might be a space near the margin where the user
+			// clicks which might result in a col or row outside the bounds of terminal,
+			selection.SelectWordOrExpression (-1, 0);
+			selection.SelectWordOrExpression (11, 0);
+		}
+
+		[Fact]
+		public void DoesNotCrashWhenSelectingWordOrExpressionOutsideRowRange ()
+		{
+			var terminal = new Terminal (null, new TerminalOptions { Rows = 10, Cols = 10, Scrollback = 0 });
+			var selection = new SelectionService (terminal);
+
+			terminal.Feed ("1234567890");
+
+			// depending on the size of terminal view, there might be a space near the margin where the user
+			// clicks which might result in a col or row outside the bounds of terminal,
+			selection.SelectWordOrExpression (0, -1);
+		}
+	}
+}

--- a/XtermSharp/Buffer.cs
+++ b/XtermSharp/Buffer.cs
@@ -124,6 +124,9 @@ namespace XtermSharp {
 				return CharData.Null;
 			}
 
+			if (col >= bufferRow.Length || col < 0)
+				return CharData.Null;
+
 			return bufferRow [col];
 		}
 

--- a/XtermSharp/SelectionService.cs
+++ b/XtermSharp/SelectionService.cs
@@ -166,8 +166,13 @@ namespace XtermSharp {
 		/// </summary>
 		public void SelectWordOrExpression(int col, int row)
 		{
-			row += terminal.Buffer.YDisp;
 			var buffer = terminal.Buffer;
+
+			// ensure the bounds are inside the terminal.
+			row = Math.Max (row, 0);
+			col = Math.Max (Math.Min (col, terminal.Buffer.Cols), 0);
+
+			row += buffer.YDisp;
 
 			Func<CharData, bool> isLetterOrChar = (cd) => {
 				if (cd.IsNullChar ())


### PR DESCRIPTION
XtermSharp.Buffer.GetChar(Int32,Int32)
XtermSharp.SelectionService.SelectWordOrExpression(Int32,Int32)
XtermSharp.Mac.TerminalView.MouseUp(NSEvent)